### PR TITLE
strip script name from argv before parsing

### DIFF
--- a/pipautocompile.py
+++ b/pipautocompile.py
@@ -42,7 +42,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("files", nargs="+")
 
-    args, other_args = parser.parse_known_args(sys.argv)
+    args, other_args = parser.parse_known_args(sys.argv[1:])
 
     files = sorted({pathlib.Path(p).with_suffix(".in") for p in args.files})
 


### PR DESCRIPTION
https://github.com/python/cpython/blob/f56c75ed53dcad4d59dff4377ae463d6b96acd3e/Lib/argparse.py#L1774-L1780